### PR TITLE
dont overwrite users props.keen object

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -5,6 +5,7 @@
 
 var extend = require('extend');
 var addons = require('./addons');
+var objectCase = require('obj-case');
 
 /**
  * Map `track`.
@@ -18,6 +19,12 @@ exports.track = function(track, settings){
   var props = track.properties();
   var options = track.options(this.name);
   var traits = options.traits || {};
+  // don't overwrite user's Keen Object and use objectCase
+  // in case the casing is funky
+  var keenObject = objectCase.find(props, 'keen') || {};
+  objectCase.del(props, 'keen');
+  props['keen'] = keenObject;
+  props.keen.timestamp = track.timestamp();
   var ret = {};
 
   extend(props, {
@@ -26,9 +33,7 @@ exports.track = function(track, settings){
     user_agent: track.userAgent(),
     ip_address: track.ip(),
     traits: traits,
-    keen: {
-      timestamp: track.timestamp()
-    }
+    keen: props.keen
   });
 
   var adds = props.keen.addons = [];

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "batch": "^0.5.1",
     "extend": "^2.0.0",
+    "obj-case": "^0.2.0",
     "segmentio-integration": "^3.2.0"
   },
   "devDependencies": {

--- a/test/fixtures/keen-props.json
+++ b/test/fixtures/keen-props.json
@@ -1,0 +1,46 @@
+{
+  "input": {
+    "anonymousId": "user-id",
+    "event": "my-event",
+    "type": "track",
+    "timestamp": "2014",
+    "properties": {
+      "url": "https://segment.io/docs",
+      "Keen": {
+        "location": {
+          "coordinates": "grog"
+        }
+      }
+    },
+    "context": {
+      "userAgent": "user-agent",
+      "ip": "0.0.0.0"
+    },
+    "integrations": {
+      "Keen IO": {
+        "traits": {
+          "user-name": "user-name"
+        }
+      }
+    }
+  },
+  "output": {
+    "my-event": [{
+      "userId": "user-id",
+      "ip_address": "0.0.0.0",
+      "user_agent": "user-agent",
+      "page_url": "https://segment.io/docs",
+      "url": "https://segment.io/docs",
+      "traits": {
+        "user-name": "user-name"
+      },
+      "keen": {
+        "timestamp": "2014-01-01T00:00:00.000Z",
+        "location": {
+          "coordinates": "grog"
+        },
+        "addons": []
+      }
+    }]
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,10 @@ describe('Keen IO', function () {
         test.maps('traits');
       });
 
+      it('should respect props.keen object', function(){
+        test.maps('keen-props');
+      });
+
       it('should add ip addon when .ipAddon is `true`', function(){
         test.maps('ip-addon');
       });


### PR DESCRIPTION
Currently, we're overwriting user's Keen Objects so they can't take advantage of features like [Geo-filtering](https://keen.io/docs/api/#geo-filtering)

This branch makes it so that we check (case-insensitive) for a `Keen` object on the track calls properties and we attach the whole object to the props object.